### PR TITLE
rename schemaForType to schemaAsFormat

### DIFF
--- a/src/components/OperationExplorer.tsx
+++ b/src/components/OperationExplorer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import List, { ListRow } from "./common/List";
 import Toolbar from "./common/Toolbar";
-import { Tab } from "./common/Toolbar/Tabs";
+import { Tabs} from "./common/Toolbar/Tabs";
 import ThemeProvider from "./common/themes/provider";
 
 import Operation from "./Operation";

--- a/src/components/Schema.tsx
+++ b/src/components/Schema.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { useMonacoEditor } from "use-monaco";
 import { useRecoilValue, useRecoilState } from "recoil";
-import { schemaForType } from "../recoil/schemas/selectors";
+import { schemaAsFormat } from "../recoil/schemas/selectors";
 import { editorByKey } from "../recoil/editors/selectors";
 
 const uri = "https://swapi-graphql.netlify.app/.netlify/functions/index";
 
 function Schema() {
-  const schemaString = useRecoilValue(schemaForType({ uri, type: "SDL" }));
+  const schemaString = useRecoilValue(schemaAsFormat({ uri, outputFormat: "SDL" }));
   const [, setEditor] = useRecoilState(editorByKey("operation"));
 
   const { containerRef, monaco, model, loading, editor } = useMonacoEditor({


### PR DESCRIPTION
This PR is to rename `schemaForType` to `schemaAsFormat` as it is a typo.